### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/jBernavaPrah/asterisk-ari-rs/compare/v0.1.1...v0.2.0) - 2025-03-09
+
+### Added
+
+- Added multiple improvements on the errors and ws connections and disconnections.
+
+### Other
+
+- fix release
+- Moved asterisk into examples directory. Improved docs.
+- Move asterisk docker compose to asterisk directory.
+
 ## [0.1.1](https://github.com/jBernavaPrah/asterisk-ari-rs/compare/v0.1.0...v0.1.1) - 2025-03-08
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "asterisk-ari"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asterisk-ari"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.65.0"
 description = "Asterisk ARI client"


### PR DESCRIPTION



## 🤖 New release

* `asterisk-ari`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `asterisk-ari` breaking changes

```text
--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type Client no longer derives Clone, in /tmp/.tmpVYg2vj/asterisk-ari-rs/src/ws/client.rs:17
  type Client no longer derives Clone, in /tmp/.tmpVYg2vj/asterisk-ari-rs/src/apis/client.rs:13

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_variant_added.ron

Failed in:
  variant AriError:Internal in /tmp/.tmpVYg2vj/asterisk-ari-rs/src/errors.rs:35

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_variant_missing.ron

Failed in:
  variant AriError::HttpInvalidHeader, previously in file /tmp/.tmp5JEz7d/asterisk-ari/src/errors.rs:18

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/inherent_method_missing.ron

Failed in:
  AriClient::ws, previously in file /tmp/.tmp5JEz7d/asterisk-ari/src/client.rs:126
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/jBernavaPrah/asterisk-ari-rs/compare/v0.1.1...v0.2.0) - 2025-03-09

### Added

- Added multiple improvements on the errors and ws connections and disconnections.

### Other

- fix release
- Moved asterisk into examples directory. Improved docs.
- Move asterisk docker compose to asterisk directory.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).