### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/jBernavaPrah/asterisk-ari-rs/compare/v0.2.0...v0.3.0) - 2025-03-10
+
+### Added
+
+- Added on WS Client the retry and the await on the disconnect. Added managing the errors on callbacks (for now simply tracing::error). Fix minor api error.
+
 ## [0.2.0](https://github.com/jBernavaPrah/asterisk-ari-rs/compare/v0.1.1...v0.2.0) - 2025-03-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "asterisk-ari"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asterisk-ari"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.65.0"
 description = "Asterisk ARI client"


### PR DESCRIPTION



## 🤖 New release

* `asterisk-ari`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `asterisk-ari` breaking changes

```text
--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---

Description:
A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_tuple_variant_changed_kind.ron

Failed in:
  variant AriError::Http in /tmp/.tmpRDrot2/asterisk-ari-rs/src/errors.rs:26
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/jBernavaPrah/asterisk-ari-rs/compare/v0.2.0...v0.3.0) - 2025-03-10

### Added

- Added on WS Client the retry and the await on the disconnect. Added managing the errors on callbacks (for now simply tracing::error). Fix minor api error.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).