### PR TITLE
Add client_arc method to return cloned API client

### DIFF
--- a/src/apis/recordings/mod.rs
+++ b/src/apis/recordings/mod.rs
@@ -122,7 +122,7 @@ impl LiveRecordings<'_> {
     pub async fn stop(
         &self,
         recording_name: impl Into<String> + Send,
-    ) -> crate::errors::Result<models::StoredRecording> {
+    ) -> crate::errors::Result<()> {
         self.client
             .post(
                 format!("/recordings/live/{}/stop", recording_name.into()).as_str(),

--- a/src/apis/recordings/models.rs
+++ b/src/apis/recordings/models.rs
@@ -43,6 +43,8 @@ pub enum LiveRecordingState {
     Done,
     #[serde(rename = "failed")]
     Failed,
+    #[serde(rename = "queued")]
+    Queued,
 }
 
 /// StoredRecording:

--- a/src/client.rs
+++ b/src/client.rs
@@ -113,6 +113,11 @@ impl AriClient {
     pub fn client(&self) -> &apis::client::Client {
         &self.client
     }
+
+    /// Returns a reference to the API client.
+    pub fn client_arc(&self) -> Arc<Client> {
+        self.client.clone()
+    }
 }
 
 impl Deref for AriClient {

--- a/src/client.rs
+++ b/src/client.rs
@@ -115,7 +115,7 @@ impl AriClient {
     }
 
     /// Returns a reference to the API client.
-    pub fn client_arc(&self) -> Arc<Client> {
+    pub fn client_arc(&self) -> Arc<apis::client::Client> {
         self.client.clone()
     }
 }


### PR DESCRIPTION
`AriClient` internally stores the API client as `client: Arc<apis::client::Client>`. However, the current accessor is defined as:

```rust
pub fn client(&self) -> &apis::client::Client {
    &self.client
}
```

Because `Arc<T>` dereferences to `T`, this coerces to `&Client`, preventing callers from moving the client into spawned async tasks.  Returning `Arc<Client>` allows callers to cheaply clone and move the client where needed.

Proposed Change

```rust
/// add a method to return a clone of the underlying API client `Arc`.
pub fn client_arc(&self) -> Arc<apis::client::Client> {
    self.client.clone()
}
```