### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/jBernavaPrah/asterisk-ari-rs/compare/v0.3.0...v0.3.1) - 2026-03-12
+
+### Other
+
+- *(deps)* bump actions/checkout from 4 to 6 ([#8](https://github.com/jBernavaPrah/asterisk-ari-rs/pull/8))
+
 ## [0.3.0](https://github.com/jBernavaPrah/asterisk-ari-rs/compare/v0.2.0...v0.3.0) - 2025-03-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "asterisk-ari"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asterisk-ari"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.65.0"
 description = "Asterisk ARI client"


### PR DESCRIPTION



## 🤖 New release

* `asterisk-ari`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/jBernavaPrah/asterisk-ari-rs/compare/v0.3.0...v0.3.1) - 2026-03-12

### Other

- *(deps)* bump actions/checkout from 4 to 6 ([#8](https://github.com/jBernavaPrah/asterisk-ari-rs/pull/8))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).